### PR TITLE
sample_encode prints wrong Implementation info on multiple graphic adapters environment

### DIFF
--- a/samples/sample_encode/src/pipeline_encode.cpp
+++ b/samples/sample_encode/src/pipeline_encode.cpp
@@ -1587,7 +1587,10 @@ void CEncodingPipeline::PrintInfo()
     GetFirstSession().QueryIMPL(&impl);
 
     const msdk_char* sImpl = (MFX_IMPL_VIA_D3D11 == MFX_IMPL_VIA_MASK(impl)) ? MSDK_STRING("hw_d3d11")
-                     : (MFX_IMPL_HARDWARE & impl)  ? MSDK_STRING("hw")
+                     : (MFX_IMPL_HARDWARE  & impl) ? MSDK_STRING("hw1")
+                     : (MFX_IMPL_HARDWARE2 & impl) ? MSDK_STRING("hw2")
+                     : (MFX_IMPL_HARDWARE3 & impl) ? MSDK_STRING("hw3")
+                     : (MFX_IMPL_HARDWARE4 & impl) ? MSDK_STRING("hw4")
                                                    : MSDK_STRING("sw");
     msdk_printf(MSDK_STRING("Media SDK impl\t\t%s\n"), sImpl);
 


### PR DESCRIPTION
**Current sample_encode prints 'hw' if only Intel Graphic adapter is default device**. If multiple graphic adapters are existed in PC and Intel graphic adapter is secondary device, sample_encode prints like below,

> Media SDK impl : sw

This is wrong information because sample_encode had the success [to initialize  mfxInitParam.Implementation with MFX_IMPL_HARDWARE_ANY](https://github.com/Intel-Media-SDK/samples/blob/master/samples/sample_encode/src/pipeline_encode.cpp#L1008).
On multiple graphic adapters environment sample_encode must print like below,

> Media SDK imple : hw
