### PR TITLE
Three patches for sample_multi_trancode

### DIFF
--- a/samples/sample_multi_transcode/src/pipeline_transcode.cpp
+++ b/samples/sample_multi_transcode/src/pipeline_transcode.cpp
@@ -953,7 +953,7 @@ mfxStatus CTranscodingPipeline::Decode()
             break;
         }
 
-        msdk_tick nFrameTime = msdk_time_get_tick() - nBeginTime;
+        msdk_tick nFrameTime = (msdk_time_get_tick() - nBeginTime) * 1000000 / msdk_time_get_frequency();
         if (nFrameTime < m_nReqFrameTime)
         {
             MSDK_USLEEP((mfxU32)(m_nReqFrameTime - nFrameTime));
@@ -1240,7 +1240,7 @@ mfxStatus CTranscodingPipeline::Encode()
             break;
         }
 
-        msdk_tick nFrameTime = msdk_time_get_tick() - nBeginTime;
+        msdk_tick nFrameTime = (msdk_time_get_tick() - nBeginTime) * 1000000 / msdk_time_get_frequency();
         if (nFrameTime < m_nReqFrameTime)
         {
             MSDK_USLEEP((mfxU32)(m_nReqFrameTime - nFrameTime));
@@ -1540,7 +1540,7 @@ mfxStatus CTranscodingPipeline::Transcode()
             MSDK_CHECK_STATUS(sts, "PutBS failed");
         }
 
-        msdk_tick nFrameTime = msdk_time_get_tick() - nBeginTime;
+        msdk_tick nFrameTime = (msdk_time_get_tick() - nBeginTime) * 1000000 / msdk_time_get_frequency();
         if (nFrameTime < m_nReqFrameTime)
         {
             MSDK_USLEEP((mfxU32)(m_nReqFrameTime - nFrameTime));

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -1505,6 +1505,11 @@ mfxStatus CmdProcessor::VerifyAndCorrectInputParams(TranscodingSample::sInputPar
         return MFX_ERR_UNSUPPORTED;
     }
 
+    if(InputParams.EncodeId == MFX_FOURCC_DUMP && InputParams.bUseOpaqueMemory)
+    {
+        InputParams.bUseOpaqueMemory = false;
+    }
+
     return MFX_ERR_NONE;
 } //mfxStatus CmdProcessor::VerifyAndCorrectInputParams(TranscodingSample::sInputParams &InputParams)
 

--- a/samples/sample_multi_transcode/src/transcode_utils.cpp
+++ b/samples/sample_multi_transcode/src/transcode_utils.cpp
@@ -504,8 +504,6 @@ mfxStatus CmdProcessor::ParseParFile(FILE *parFile)
         sts = TokenizeLine(pCur, currPos);
         MSDK_CHECK_STATUS(sts, "TokenizeLine failed");
 
-        // save original cmd line for debug purposes
-        m_lines.push_back(msdk_string(pCur, currPos));
         currPos = 0;
         lineIndex++;
     }


### PR DESCRIPTION
If par file is provided each session cmd line is saved twice into m_lines. At final output it would be confusing.